### PR TITLE
Refactor FlowEngine to use Visitor pattern

### DIFF
--- a/docs/ApiBlueprint.cs
+++ b/docs/ApiBlueprint.cs
@@ -132,7 +132,7 @@ namespace BahmanM.Flow.Behaviours.Retry
 //========================================================================================
 namespace BahmanM.Flow.Execution
 {
-    public static class FlowEngine
+    public class FlowEngine
     {
         public static Task<Outcome<T>> ExecuteAsync<T>(IFlow<T> flow, FlowExecutionOptions options = null);
     }

--- a/src/BahmanM.Flow/FlowEngine.cs
+++ b/src/BahmanM.Flow/FlowEngine.cs
@@ -2,61 +2,106 @@ using static BahmanM.Flow.Outcome;
 
 namespace BahmanM.Flow;
 
-public static class FlowEngine
+public class FlowEngine
 {
+    #region Public API
+    
     public static Task<Outcome<T>> ExecuteAsync<T>(IFlow<T> flow)
     {
-        return flow switch
+        // A safe, controlled cast as Flow owns all (sub)types.
+        var executableFlow = (IVisitableFlow<T>)flow;
+        return executableFlow.ExecuteWith(new FlowEngine());
+    }
+
+    #endregion
+
+    #region Constructors
+    
+    private FlowEngine() { }
+
+    #endregion
+
+    #region Visitor Methods
+
+    internal Task<Outcome<T>> Execute<T>(SucceededFlow<T> flow) =>
+        Task.FromResult(Success(flow.Value));
+
+    internal Task<Outcome<T>> Execute<T>(FailedFlow<T> flow) =>
+        Task.FromResult(Failure<T>(flow.Exception));
+
+    internal Task<Outcome<T>> Execute<T>(CreateFlow<T> flow) =>
+        TryOperation(flow.Operation);
+
+    internal Task<Outcome<T>> Execute<T>(AsyncCreateFlow<T> flow) =>
+        TryOperation(flow.Operation);
+
+    internal async Task<Outcome<T>> Execute<T>(DoOnSuccessFlow<T> flow)
+    {
+        var upstreamOutcome = await ((IVisitableFlow<T>)flow.Upstream).ExecuteWith(this);
+
+        if (upstreamOutcome is Success<T> success)
         {
-            SucceededFlow<T> s => Task.FromResult(Success(s.Value)),
-            FailedFlow<T> f => Task.FromResult(Failure<T>(f.Exception)),
-            CreateFlow<T> c => TryOperation(c.Operation),
-            AsyncCreateFlow<T> ac => TryOperation(ac.Operation),
-            DoOnSuccessFlow<T> dos => HandleDoOnSuccess(dos.Upstream, dos.Action),
-            AsyncDoOnSuccessFlow<T> ados => HandleDoOnSuccess(ados.Upstream, ados.AsyncAction),
-            _ => throw new NotSupportedException($"Unsupported source flow type: {flow.GetType().Name}")
+            try
+            {
+                flow.Action(success.Value);
+                return upstreamOutcome;
+            }
+            catch (Exception ex)
+            {
+                return Failure<T>(ex);
+            }
+        }
+
+        return upstreamOutcome;
+    }
+
+    internal async Task<Outcome<T>> Execute<T>(AsyncDoOnSuccessFlow<T> flow)
+    {
+        var upstreamOutcome = await ((IVisitableFlow<T>)flow.Upstream).ExecuteWith(this);
+
+        if (upstreamOutcome is Success<T> success)
+        {
+            try
+            {
+                await flow.AsyncAction(success.Value);
+                return upstreamOutcome;
+            }
+            catch (Exception ex)
+            {
+                return Failure<T>(ex);
+            }
+        }
+
+        return upstreamOutcome;
+    }
+
+    internal async Task<Outcome<TOut>> Execute<TIn, TOut>(SelectFlow<TIn, TOut> flow)
+    {
+        var upstreamOutcome = await ((IVisitableFlow<TIn>)flow.Upstream).ExecuteWith(this);
+
+        return upstreamOutcome switch
+        {
+            Success<TIn> s => await TryOperation(() => flow.Operation(s.Value)),
+            Failure<TIn> f => Failure<TOut>(f.Exception),
+            _ => throw new NotSupportedException($"Unsupported outcome type: {upstreamOutcome.GetType().Name}")
         };
     }
 
-    private static async Task<Outcome<T>> HandleDoOnSuccess<T>(IFlow<T> upstream, Action<T> action)
+    internal async Task<Outcome<TOut>> Execute<TIn, TOut>(AsyncSelectFlow<TIn, TOut> flow)
     {
-        var upstreamOutcome = await ExecuteAsync(upstream);
+        var upstreamOutcome = await ((IVisitableFlow<TIn>)flow.Upstream).ExecuteWith(this);
 
-        if (upstreamOutcome is Success<T> success)
+        return upstreamOutcome switch
         {
-            try
-            {
-                action(success.Value);
-                return upstreamOutcome;
-            }
-            catch (Exception ex)
-            {
-                return Failure<T>(ex);
-            }
-        }
-
-        return upstreamOutcome;
+            Success<TIn> s => await TryOperation(() => flow.Operation(s.Value)),
+            Failure<TIn> f => Failure<TOut>(f.Exception),
+            _ => throw new NotSupportedException($"Unsupported outcome type: {upstreamOutcome.GetType().Name}")
+        };
     }
 
-    private static async Task<Outcome<T>> HandleDoOnSuccess<T>(IFlow<T> upstream, Func<T, Task> asyncAction)
-    {
-        var upstreamOutcome = await ExecuteAsync(upstream);
+    #endregion
 
-        if (upstreamOutcome is Success<T> success)
-        {
-            try
-            {
-                await asyncAction(success.Value);
-                return upstreamOutcome;
-            }
-            catch (Exception ex)
-            {
-                return Failure<T>(ex);
-            }
-        }
-
-        return upstreamOutcome;
-    }
+    #region Private Helpers
 
     private static Task<Outcome<T>> TryOperation<T>(Func<T> operation)
     {
@@ -81,4 +126,6 @@ public static class FlowEngine
             return Failure<T>(ex);
         }
     }
+
+    #endregion
 }

--- a/src/BahmanM.Flow/FlowEngine.cs
+++ b/src/BahmanM.Flow/FlowEngine.cs
@@ -75,30 +75,6 @@ public class FlowEngine
         return upstreamOutcome;
     }
 
-    internal async Task<Outcome<TOut>> Execute<TIn, TOut>(SelectFlow<TIn, TOut> flow)
-    {
-        var upstreamOutcome = await ((IVisitableFlow<TIn>)flow.Upstream).ExecuteWith(this);
-
-        return upstreamOutcome switch
-        {
-            Success<TIn> s => await TryOperation(() => flow.Operation(s.Value)),
-            Failure<TIn> f => Failure<TOut>(f.Exception),
-            _ => throw new NotSupportedException($"Unsupported outcome type: {upstreamOutcome.GetType().Name}")
-        };
-    }
-
-    internal async Task<Outcome<TOut>> Execute<TIn, TOut>(AsyncSelectFlow<TIn, TOut> flow)
-    {
-        var upstreamOutcome = await ((IVisitableFlow<TIn>)flow.Upstream).ExecuteWith(this);
-
-        return upstreamOutcome switch
-        {
-            Success<TIn> s => await TryOperation(() => flow.Operation(s.Value)),
-            Failure<TIn> f => Failure<TOut>(f.Exception),
-            _ => throw new NotSupportedException($"Unsupported outcome type: {upstreamOutcome.GetType().Name}")
-        };
-    }
-
     #endregion
 
     #region Private Helpers

--- a/src/BahmanM.Flow/FlowExtensions.cs
+++ b/src/BahmanM.Flow/FlowExtensions.cs
@@ -7,10 +7,4 @@ public static class FlowExtensions
 
     public static IFlow<T> DoOnSuccess<T>(this IFlow<T> flow, Func<T, Task> asyncAction) =>
         new AsyncDoOnSuccessFlow<T>(flow, asyncAction);
-
-    public static IFlow<TOut> Select<TIn, TOut>(this IFlow<TIn> flow, Func<TIn, TOut> operation) =>
-        new SelectFlow<TIn, TOut>(flow, operation);
-
-    public static IFlow<TOut> Select<TIn, TOut>(this IFlow<TIn> flow, Func<TIn, Task<TOut>> asyncOperation) =>
-        new AsyncSelectFlow<TIn, TOut>(flow, asyncOperation);
 }

--- a/src/BahmanM.Flow/FlowExtensions.cs
+++ b/src/BahmanM.Flow/FlowExtensions.cs
@@ -7,4 +7,10 @@ public static class FlowExtensions
 
     public static IFlow<T> DoOnSuccess<T>(this IFlow<T> flow, Func<T, Task> asyncAction) =>
         new AsyncDoOnSuccessFlow<T>(flow, asyncAction);
+
+    public static IFlow<TOut> Select<TIn, TOut>(this IFlow<TIn> flow, Func<TIn, TOut> operation) =>
+        new SelectFlow<TIn, TOut>(flow, operation);
+
+    public static IFlow<TOut> Select<TIn, TOut>(this IFlow<TIn> flow, Func<TIn, Task<TOut>> asyncOperation) =>
+        new AsyncSelectFlow<TIn, TOut>(flow, asyncOperation);
 }

--- a/src/BahmanM.Flow/FlowTypes.cs
+++ b/src/BahmanM.Flow/FlowTypes.cs
@@ -44,18 +44,4 @@ internal sealed record AsyncDoOnSuccessFlow<T>(IFlow<T> Upstream, Func<T, Task> 
 
 #endregion
 
-#region Select
-
-internal sealed record SelectFlow<TIn, TOut>(IFlow<TIn> Upstream, Func<TIn, TOut> Operation) : IVisitableFlow<TOut>
-{
-    public Task<Outcome<TOut>> ExecuteWith(FlowEngine engine) => engine.Execute(this);
-}
-
-internal sealed record AsyncSelectFlow<TIn, TOut>(IFlow<TIn> Upstream, Func<TIn, Task<TOut>> Operation) : IVisitableFlow<TOut>
-{
-    public Task<Outcome<TOut>> ExecuteWith(FlowEngine engine) => engine.Execute(this);
-}
-
-#endregion
-
 #endregion

--- a/src/BahmanM.Flow/FlowTypes.cs
+++ b/src/BahmanM.Flow/FlowTypes.cs
@@ -1,13 +1,61 @@
 namespace BahmanM.Flow;
 
-internal sealed record SucceededFlow<T>(T Value) : IFlow<T>;
+#region Internal Flow AST Nodes
 
-internal sealed record FailedFlow<T>(Exception Exception) : IFlow<T>;
+#region Source
 
-internal sealed record CreateFlow<T>(Func<T> Operation) : IFlow<T>;
+internal sealed record SucceededFlow<T>(T Value) : IVisitableFlow<T>
+{
+    public Task<Outcome<T>> ExecuteWith(FlowEngine engine) => engine.Execute(this);
+}
 
-internal sealed record AsyncCreateFlow<T>(Func<Task<T>> Operation) : IFlow<T>;
+internal sealed record FailedFlow<T>(Exception Exception) : IVisitableFlow<T>
+{
+    public Task<Outcome<T>> ExecuteWith(FlowEngine engine) => engine.Execute(this);
+}
 
-internal sealed record DoOnSuccessFlow<T>(IFlow<T> Upstream, Action<T> Action) : IFlow<T>;
+#endregion
 
-internal sealed record AsyncDoOnSuccessFlow<T>(IFlow<T> Upstream, Func<T, Task> AsyncAction) : IFlow<T>;
+#region Create
+
+internal sealed record CreateFlow<T>(Func<T> Operation) : IVisitableFlow<T>
+{
+    public Task<Outcome<T>> ExecuteWith(FlowEngine engine) => engine.Execute(this);
+}
+
+internal sealed record AsyncCreateFlow<T>(Func<Task<T>> Operation) : IVisitableFlow<T>
+{
+    public Task<Outcome<T>> ExecuteWith(FlowEngine engine) => engine.Execute(this);
+}
+
+#endregion
+
+#region DoOnSuccess
+
+internal sealed record DoOnSuccessFlow<T>(IFlow<T> Upstream, Action<T> Action) : IVisitableFlow<T>
+{
+    public Task<Outcome<T>> ExecuteWith(FlowEngine engine) => engine.Execute(this);
+}
+
+internal sealed record AsyncDoOnSuccessFlow<T>(IFlow<T> Upstream, Func<T, Task> AsyncAction) : IVisitableFlow<T>
+{
+    public Task<Outcome<T>> ExecuteWith(FlowEngine engine) => engine.Execute(this);
+}
+
+#endregion
+
+#region Select
+
+internal sealed record SelectFlow<TIn, TOut>(IFlow<TIn> Upstream, Func<TIn, TOut> Operation) : IVisitableFlow<TOut>
+{
+    public Task<Outcome<TOut>> ExecuteWith(FlowEngine engine) => engine.Execute(this);
+}
+
+internal sealed record AsyncSelectFlow<TIn, TOut>(IFlow<TIn> Upstream, Func<TIn, Task<TOut>> Operation) : IVisitableFlow<TOut>
+{
+    public Task<Outcome<TOut>> ExecuteWith(FlowEngine engine) => engine.Execute(this);
+}
+
+#endregion
+
+#endregion

--- a/src/BahmanM.Flow/IFlow.cs
+++ b/src/BahmanM.Flow/IFlow.cs
@@ -1,5 +1,14 @@
 namespace BahmanM.Flow;
 
-public interface IFlow<out T>
+public interface IFlow<T>
 {
 }
+
+#region Internal Contracts
+
+internal interface IVisitableFlow<T> : IFlow<T>
+{
+    Task<Outcome<T>> ExecuteWith(FlowEngine engine);
+}
+
+#endregion


### PR DESCRIPTION
This PR resolves issue #53. It refactors the `FlowEngine` from a recursive, switch-based implementation to a more robust and extensible Visitor pattern. This provides compile-time static safety for all flow operations without polluting the public `IFlow` interface. It uses an internal `IVisitableFlow` interface to hook into the engine, ensuring a lean public API.