### PR TITLE
13 - Implement Select operator

### DIFF
--- a/src/BahmanM.Flow/Flow.cs
+++ b/src/BahmanM.Flow/Flow.cs
@@ -2,11 +2,11 @@ namespace BahmanM.Flow;
 
 public static class Flow
 {
-    public static IFlow<T> Succeed<T>(T value) => new SucceededFlow<T>(value);
+    public static IFlow<T> Succeed<T>(T value) => new SucceededNode<T>(value);
 
-    public static IFlow<T> Fail<T>(Exception exception) => new FailedFlow<T>(exception);
+    public static IFlow<T> Fail<T>(Exception exception) => new FailedNode<T>(exception);
 
-    public static IFlow<T> Create<T>(Func<T> operation) => new CreateFlow<T>(operation);
+    public static IFlow<T> Create<T>(Func<T> operation) => new CreateNode<T>(operation);
 
-    public static IFlow<T> Create<T>(Func<Task<T>> operation) => new AsyncCreateFlow<T>(operation);
+    public static IFlow<T> Create<T>(Func<Task<T>> operation) => new AsyncCreateNode<T>(operation);
 }

--- a/src/BahmanM.Flow/FlowEngine.cs
+++ b/src/BahmanM.Flow/FlowEngine.cs
@@ -1,72 +1,114 @@
-using static BahmanM.Flow.Outcome;
-
 namespace BahmanM.Flow;
 
-public static class FlowEngine
+public class FlowEngine
 {
+    #region Public API
+
     public static Task<Outcome<T>> ExecuteAsync<T>(IFlow<T> flow)
     {
-        return flow switch
+        var node = (IFlowNode<T>)flow;
+        return node.ExecuteWith(new FlowEngine());
+    }
+
+    #endregion
+
+    #region Constructors
+
+    private FlowEngine() { }
+
+    #endregion
+
+    #region Visitor Methods
+
+    internal Task<Outcome<T>> Execute<T>(SucceededNode<T> node) =>
+        Task.FromResult(Outcome.Success(node.Value));
+
+    internal Task<Outcome<T>> Execute<T>(FailedNode<T> node) =>
+        Task.FromResult(Outcome.Failure<T>(node.Exception));
+
+    internal Task<Outcome<T>> Execute<T>(CreateNode<T> node) =>
+        TryOperation(node.Operation);
+
+    internal Task<Outcome<T>> Execute<T>(AsyncCreateNode<T> node) =>
+        TryOperation(node.Operation);
+
+    internal async Task<Outcome<T>> Execute<T>(DoOnSuccessNode<T> node)
+    {
+        var upstreamOutcome = await ((IFlowNode<T>)node.Upstream).ExecuteWith(this);
+
+        if (upstreamOutcome is Success<T> success)
         {
-            SucceededFlow<T> s => Task.FromResult(Success(s.Value)),
-            FailedFlow<T> f => Task.FromResult(Failure<T>(f.Exception)),
-            CreateFlow<T> c => TryOperation(c.Operation),
-            AsyncCreateFlow<T> ac => TryOperation(ac.Operation),
-            DoOnSuccessFlow<T> dos => HandleDoOnSuccess(dos.Upstream, dos.Action),
-            AsyncDoOnSuccessFlow<T> ados => HandleDoOnSuccess(ados.Upstream, ados.AsyncAction),
-            _ => throw new NotSupportedException($"Unsupported source flow type: {flow.GetType().Name}")
+            try
+            {
+                node.Action(success.Value);
+                return upstreamOutcome;
+            }
+            catch (Exception ex)
+            {
+                return Outcome.Failure<T>(ex);
+            }
+        }
+
+        return upstreamOutcome;
+    }
+
+    internal async Task<Outcome<T>> Execute<T>(AsyncDoOnSuccessNode<T> node)
+    {
+        var upstreamOutcome = await ((IFlowNode<T>)node.Upstream).ExecuteWith(this);
+
+        if (upstreamOutcome is Success<T> success)
+        {
+            try
+            {
+                await node.AsyncAction(success.Value);
+                return upstreamOutcome;
+            }
+            catch (Exception ex)
+            {
+                return Outcome.Failure<T>(ex);
+            }
+        }
+
+        return upstreamOutcome;
+    }
+
+    internal async Task<Outcome<TOut>> Execute<TIn, TOut>(SelectNode<TIn, TOut> node)
+    {
+        var upstreamOutcome = await ((IFlowNode<TIn>)node.Upstream).ExecuteWith(this);
+
+        return upstreamOutcome switch
+        {
+            Success<TIn> s => await TryOperation(() => node.Operation(s.Value)),
+            Failure<TIn> f => Outcome.Failure<TOut>(f.Exception),
+            _ => throw new NotSupportedException($"Unsupported outcome type: {upstreamOutcome.GetType().Name}")
         };
     }
 
-    private static async Task<Outcome<T>> HandleDoOnSuccess<T>(IFlow<T> upstream, Action<T> action)
+    internal async Task<Outcome<TOut>> Execute<TIn, TOut>(AsyncSelectNode<TIn, TOut> node)
     {
-        var upstreamOutcome = await ExecuteAsync(upstream);
+        var upstreamOutcome = await ((IFlowNode<TIn>)node.Upstream).ExecuteWith(this);
 
-        if (upstreamOutcome is Success<T> success)
+        return upstreamOutcome switch
         {
-            try
-            {
-                action(success.Value);
-                return upstreamOutcome;
-            }
-            catch (Exception ex)
-            {
-                return Failure<T>(ex);
-            }
-        }
-
-        return upstreamOutcome;
+            Success<TIn> s => await TryOperation(async () => await node.Operation(s.Value)),
+            Failure<TIn> f => Outcome.Failure<TOut>(f.Exception),
+            _ => throw new NotSupportedException($"Unsupported outcome type: {upstreamOutcome.GetType().Name}")
+        };
     }
 
-    private static async Task<Outcome<T>> HandleDoOnSuccess<T>(IFlow<T> upstream, Func<T, Task> asyncAction)
-    {
-        var upstreamOutcome = await ExecuteAsync(upstream);
+    #endregion
 
-        if (upstreamOutcome is Success<T> success)
-        {
-            try
-            {
-                await asyncAction(success.Value);
-                return upstreamOutcome;
-            }
-            catch (Exception ex)
-            {
-                return Failure<T>(ex);
-            }
-        }
-
-        return upstreamOutcome;
-    }
+    #region Private Helpers
 
     private static Task<Outcome<T>> TryOperation<T>(Func<T> operation)
     {
         try
         {
-            return Task.FromResult(Success(operation()));
+            return Task.FromResult(Outcome.Success(operation()));
         }
         catch (Exception ex)
         {
-            return Task.FromResult(Failure<T>(ex));
+            return Task.FromResult(Outcome.Failure<T>(ex));
         }
     }
 
@@ -74,11 +116,13 @@ public static class FlowEngine
     {
         try
         {
-            return Success(await operation());
+            return Outcome.Success(await operation());
         }
         catch (Exception ex)
         {
-            return Failure<T>(ex);
+            return Outcome.Failure<T>(ex);
         }
     }
+
+    #endregion
 }

--- a/src/BahmanM.Flow/FlowExtensions.cs
+++ b/src/BahmanM.Flow/FlowExtensions.cs
@@ -3,8 +3,14 @@ namespace BahmanM.Flow;
 public static class FlowExtensions
 {
     public static IFlow<T> DoOnSuccess<T>(this IFlow<T> flow, Action<T> action) =>
-        new DoOnSuccessFlow<T>(flow, action);
+        new DoOnSuccessNode<T>(flow, action);
 
     public static IFlow<T> DoOnSuccess<T>(this IFlow<T> flow, Func<T, Task> asyncAction) =>
-        new AsyncDoOnSuccessFlow<T>(flow, asyncAction);
+        new AsyncDoOnSuccessNode<T>(flow, asyncAction);
+
+    public static IFlow<TOut> Select<TIn, TOut>(this IFlow<TIn> flow, Func<TIn, TOut> operation) =>
+        new SelectNode<TIn, TOut>(flow, operation);
+
+    public static IFlow<TOut> Select<TIn, TOut>(this IFlow<TIn> flow, Func<TIn, Task<TOut>> asyncOperation) =>
+        new AsyncSelectNode<TIn, TOut>(flow, asyncOperation);
 }

--- a/src/BahmanM.Flow/FlowTypes.cs
+++ b/src/BahmanM.Flow/FlowTypes.cs
@@ -1,13 +1,70 @@
 namespace BahmanM.Flow;
 
-internal sealed record SucceededFlow<T>(T Value) : IFlow<T>;
+#region Internal Contracts
 
-internal sealed record FailedFlow<T>(Exception Exception) : IFlow<T>;
+internal interface IFlowNode<T> : IFlow<T>
+{
+    Task<Outcome<T>> ExecuteWith(FlowEngine engine);
+}
 
-internal sealed record CreateFlow<T>(Func<T> Operation) : IFlow<T>;
+#endregion
 
-internal sealed record AsyncCreateFlow<T>(Func<Task<T>> Operation) : IFlow<T>;
+#region Internal Flow AST Nodes
 
-internal sealed record DoOnSuccessFlow<T>(IFlow<T> Upstream, Action<T> Action) : IFlow<T>;
+#region Source Nodes
 
-internal sealed record AsyncDoOnSuccessFlow<T>(IFlow<T> Upstream, Func<T, Task> AsyncAction) : IFlow<T>;
+internal sealed record SucceededNode<T>(T Value) : IFlowNode<T>
+{
+    public Task<Outcome<T>> ExecuteWith(FlowEngine engine) => engine.Execute(this);
+}
+
+internal sealed record FailedNode<T>(Exception Exception) : IFlowNode<T>
+{
+    public Task<Outcome<T>> ExecuteWith(FlowEngine engine) => engine.Execute(this);
+}
+
+#endregion
+
+#region Create Nodes
+
+internal sealed record CreateNode<T>(Func<T> Operation) : IFlowNode<T>
+{
+    public Task<Outcome<T>> ExecuteWith(FlowEngine engine) => engine.Execute(this);
+}
+
+internal sealed record AsyncCreateNode<T>(Func<Task<T>> Operation) : IFlowNode<T>
+{
+    public Task<Outcome<T>> ExecuteWith(FlowEngine engine) => engine.Execute(this);
+}
+
+#endregion
+
+#region DoOnSuccess Nodes
+
+internal sealed record DoOnSuccessNode<T>(IFlow<T> Upstream, Action<T> Action) : IFlowNode<T>
+{
+    public Task<Outcome<T>> ExecuteWith(FlowEngine engine) => engine.Execute(this);
+}
+
+internal sealed record AsyncDoOnSuccessNode<T>(IFlow<T> Upstream, Func<T, Task> AsyncAction) : IFlowNode<T>
+{
+    public Task<Outcome<T>> ExecuteWith(FlowEngine engine) => engine.Execute(this);
+}
+
+#endregion
+
+#region Select Nodes
+
+internal sealed record SelectNode<TIn, TOut>(IFlow<TIn> Upstream, Func<TIn, TOut> Operation) : IFlowNode<TOut>
+{
+    public Task<Outcome<TOut>> ExecuteWith(FlowEngine engine) => engine.Execute(this);
+}
+
+internal sealed record AsyncSelectNode<TIn, TOut>(IFlow<TIn> Upstream, Func<TIn, Task<TOut>> Operation) : IFlowNode<TOut>
+{
+    public Task<Outcome<TOut>> ExecuteWith(FlowEngine engine) => engine.Execute(this);
+}
+
+#endregion
+
+#endregion

--- a/src/BahmanM.Flow/IFlow.cs
+++ b/src/BahmanM.Flow/IFlow.cs
@@ -1,5 +1,5 @@
 namespace BahmanM.Flow;
 
-public interface IFlow<out T>
+public interface IFlow<T>
 {
 }

--- a/tests/BahmanM.Flow.Tests.Unit/SelectTests.cs
+++ b/tests/BahmanM.Flow.Tests.Unit/SelectTests.cs
@@ -1,0 +1,85 @@
+using BahmanM.Flow;
+using static BahmanM.Flow.Outcome;
+
+namespace BahmanM.Flow.Tests.Unit;
+
+public class SelectTests
+{
+    [Fact]
+    public async Task WhenFlowSucceeds_AppliesSelectorAndReturnsNewSuccess()
+    {
+        // Arrange
+        var successValue = 123;
+        var flow = Flow.Succeed(successValue).Select(x => x * 2);
+
+        // Act
+        var outcome = await FlowEngine.ExecuteAsync(flow);
+
+        // Assert
+        Assert.Equal(Success(246), outcome);
+    }
+
+    [Fact]
+    public async Task WhenFlowFails_DoesNotApplySelectorAndReturnsOriginalFailure()
+    {
+        // Arrange
+        var exception = new InvalidOperationException("Test Failure");
+        var flow = Flow.Fail<int>(exception).Select(x => x * 2);
+
+        // Act
+        var outcome = await FlowEngine.ExecuteAsync(flow);
+
+        // Assert
+        Assert.Equal(Failure<int>(exception), outcome);
+    }
+
+    [Fact]
+    public async Task WhenSelectorThrows_ReturnsFailure()
+    {
+        // Arrange
+        var exception = new InvalidOperationException("Selector failed!");
+        var flow = Flow.Succeed(123).Select((Func<int, int>)(_ => throw exception));
+
+        // Act
+        var outcome = await FlowEngine.ExecuteAsync(flow);
+
+        // Assert
+        Assert.Equal(Failure<int>(exception), outcome);
+    }
+
+    [Fact]
+    public async Task WhenAsyncFlowSucceeds_AppliesAsyncSelectorAndReturnsNewSuccess()
+    {
+        // Arrange
+        var successValue = 123;
+        var flow = Flow.Succeed(successValue).Select(async x =>
+        {
+            await Task.Delay(10);
+            return x * 2;
+        });
+
+        // Act
+        var outcome = await FlowEngine.ExecuteAsync(flow);
+
+        // Assert
+        Assert.Equal(Success(246), outcome);
+    }
+
+    [Fact]
+    public async Task WhenAsyncSelectorThrows_ReturnsFailure()
+    {
+        // Arrange
+        var exception = new InvalidOperationException("Async selector failed!");
+        var flow = Flow.Succeed(123).Select<int, int>(async _ =>
+        {
+            await Task.Delay(10);
+            throw exception;
+        });
+
+        // Act
+        var outcome = await FlowEngine.ExecuteAsync(flow);
+
+        // Assert
+        Assert.Equal(Failure<int>(exception), outcome);
+    }
+}


### PR DESCRIPTION
This PR resolves issue #13 by implementing the `Select` operator.

This work is built upon a major architectural refactoring that introduces the `IFlowNode` internal interface and a Visitor pattern-based `FlowEngine`. This provides a robust, type-safe, and extensible foundation for `Select` and all future operators, while keeping the public `IFlow<T>` interface lean and clean.