### PR TITLE
[#60] Implement Chain operator

### DIFF
--- a/src/BahmanM.Flow/FlowEngine.cs
+++ b/src/BahmanM.Flow/FlowEngine.cs
@@ -96,6 +96,19 @@ public class FlowEngine
         };
     }
 
+    internal async Task<Outcome<TOut>> Execute<TIn, TOut>(ChainNode<TIn, TOut> node)
+    {
+        var upstreamOutcome = await ((IFlowNode<TIn>)node.Upstream).ExecuteWith(this);
+
+        if (upstreamOutcome is not Success<TIn> success)
+        {
+            return Outcome.Failure<TOut>(((Failure<TIn>)upstreamOutcome).Exception);
+        }
+
+        var nextFlow = (IFlowNode<TOut>)node.Operation(success.Value);
+        return await nextFlow.ExecuteWith(this);
+    }
+
     #endregion
 
     #region Private Helpers

--- a/src/BahmanM.Flow/FlowEngine.cs
+++ b/src/BahmanM.Flow/FlowEngine.cs
@@ -105,8 +105,15 @@ public class FlowEngine
             return Outcome.Failure<TOut>(((Failure<TIn>)upstreamOutcome).Exception);
         }
 
-        var nextFlow = (IFlowNode<TOut>)node.Operation(success.Value);
-        return await nextFlow.ExecuteWith(this);
+        try
+        {
+            var nextFlow = (IFlowNode<TOut>)node.Operation(success.Value);
+            return await nextFlow.ExecuteWith(this);
+        }
+        catch (Exception ex)
+        {
+            return Outcome.Failure<TOut>(ex);
+        }
     }
 
     #endregion

--- a/src/BahmanM.Flow/FlowExtensions.cs
+++ b/src/BahmanM.Flow/FlowExtensions.cs
@@ -13,4 +13,7 @@ public static class FlowExtensions
 
     public static IFlow<TOut> Select<TIn, TOut>(this IFlow<TIn> flow, Func<TIn, Task<TOut>> asyncOperation) =>
         new AsyncSelectNode<TIn, TOut>(flow, asyncOperation);
+
+    public static IFlow<TOut> Chain<TIn, TOut>(this IFlow<TIn> flow, Func<TIn, IFlow<TOut>> operation) =>
+        new ChainNode<TIn, TOut>(flow, operation);
 }

--- a/src/BahmanM.Flow/FlowExtensions.cs
+++ b/src/BahmanM.Flow/FlowExtensions.cs
@@ -16,4 +16,7 @@ public static class FlowExtensions
 
     public static IFlow<TOut> Chain<TIn, TOut>(this IFlow<TIn> flow, Func<TIn, IFlow<TOut>> operation) =>
         new ChainNode<TIn, TOut>(flow, operation);
+
+    public static IFlow<TOut> Chain<TIn, TOut>(this IFlow<TIn> flow, Func<TIn, Task<IFlow<TOut>>> asyncOperation) =>
+        new AsyncChainNode<TIn, TOut>(flow, asyncOperation);
 }

--- a/src/BahmanM.Flow/FlowTypes.cs
+++ b/src/BahmanM.Flow/FlowTypes.cs
@@ -65,6 +65,16 @@ internal sealed record AsyncSelectNode<TIn, TOut>(IFlow<TIn> Upstream, Func<TIn,
     public Task<Outcome<TOut>> ExecuteWith(FlowEngine engine) => engine.Execute(this);
 }
 
+
+#endregion
+
+#region Chain Nodes
+
+internal sealed record ChainNode<TIn, TOut>(IFlow<TIn> Upstream, Func<TIn, IFlow<TOut>> Operation) : IFlowNode<TOut>
+{
+    public Task<Outcome<TOut>> ExecuteWith(FlowEngine engine) => engine.Execute(this);
+}
+
 #endregion
 
 #endregion

--- a/src/BahmanM.Flow/FlowTypes.cs
+++ b/src/BahmanM.Flow/FlowTypes.cs
@@ -75,6 +75,11 @@ internal sealed record ChainNode<TIn, TOut>(IFlow<TIn> Upstream, Func<TIn, IFlow
     public Task<Outcome<TOut>> ExecuteWith(FlowEngine engine) => engine.Execute(this);
 }
 
+internal sealed record AsyncChainNode<TIn, TOut>(IFlow<TIn> Upstream, Func<TIn, Task<IFlow<TOut>>> Operation) : IFlowNode<TOut>
+{
+    public Task<Outcome<TOut>> ExecuteWith(FlowEngine engine) => engine.Execute(this);
+}
+
 #endregion
 
 #endregion

--- a/tests/BahmanM.Flow.Tests.Unit/ChainTests.cs
+++ b/tests/BahmanM.Flow.Tests.Unit/ChainTests.cs
@@ -20,4 +20,25 @@ public class ChainTests
         // Assert
         Assert.Equal(Success(20), outcome);
     }
+
+    [Fact]
+    public async Task Chain_OnFailedFlow_DoesNotExecuteAndPropagatesFailure()
+    {
+        // Arrange
+        var exception = new Exception("Initial failure");
+        var initialFlow = Flow.Fail<int>(exception);
+        var chainExecuted = false;
+        var chainedFlow = initialFlow.Chain(value =>
+        {
+            chainExecuted = true;
+            return Flow.Succeed(value * 2);
+        });
+
+        // Act
+        var outcome = await FlowEngine.ExecuteAsync(chainedFlow);
+
+        // Assert
+        Assert.False(chainExecuted);
+        Assert.Equal(Failure<int>(exception), outcome);
+    }
 }

--- a/tests/BahmanM.Flow.Tests.Unit/ChainTests.cs
+++ b/tests/BahmanM.Flow.Tests.Unit/ChainTests.cs
@@ -48,12 +48,30 @@ public class ChainTests
         // Arrange
         var exception = new InvalidOperationException("Chain function failed!");
         var initialFlow = Flow.Succeed(10);
-        var chainedFlow = initialFlow.Chain<int, int>(value => throw exception);
+        var chainedFlow = initialFlow.Chain((Func<int, IFlow<int>>)(_ => throw exception));
 
         // Act
         var outcome = await FlowEngine.ExecuteAsync(chainedFlow);
 
         // Assert
         Assert.Equal(Failure<int>(exception), outcome);
+    }
+
+    [Fact]
+    public async Task AsyncChain_OnSuccessfulFlow_ExecutesAndReturnsNewFlow()
+    {
+        // Arrange
+        var initialFlow = Flow.Succeed(10);
+        var chainedFlow = initialFlow.Chain(async value =>
+        {
+            await Task.Delay(10);
+            return Flow.Succeed(value * 2);
+        });
+
+        // Act
+        var outcome = await FlowEngine.ExecuteAsync(chainedFlow);
+
+        // Assert
+        Assert.Equal(Success(20), outcome);
     }
 }

--- a/tests/BahmanM.Flow.Tests.Unit/ChainTests.cs
+++ b/tests/BahmanM.Flow.Tests.Unit/ChainTests.cs
@@ -1,0 +1,23 @@
+using static BahmanM.Flow.Outcome;
+
+namespace BahmanM.Flow.Tests.Unit;
+
+public class ChainTests
+{
+    // Al-Kindi was a 9th-century Arab philosopher, mathematician, and physician.
+    private const string AlKindi = "Al-Kindi";
+
+    [Fact]
+    public async Task Chain_OnSuccessfulFlow_ExecutesAndReturnsNewFlow()
+    {
+        // Arrange
+        var initialFlow = Flow.Succeed(10);
+        var chainedFlow = initialFlow.Chain(value => Flow.Succeed(value * 2));
+
+        // Act
+        var outcome = await FlowEngine.ExecuteAsync(chainedFlow);
+
+        // Assert
+        Assert.Equal(Success(20), outcome);
+    }
+}

--- a/tests/BahmanM.Flow.Tests.Unit/ChainTests.cs
+++ b/tests/BahmanM.Flow.Tests.Unit/ChainTests.cs
@@ -96,4 +96,19 @@ public class ChainTests
         Assert.False(chainExecuted);
         Assert.Equal(Failure<int>(exception), outcome);
     }
+
+    [Fact]
+    public async Task WhenAsyncChainFunctionThrows_ReturnsFailure()
+    {
+        // Arrange
+        var exception = new InvalidOperationException("Async chain function failed!");
+        var initialFlow = Flow.Succeed(10);
+        var chainedFlow = initialFlow.Chain((Func<int, Task<IFlow<int>>>)(_ => throw exception));
+
+        // Act
+        var outcome = await FlowEngine.ExecuteAsync(chainedFlow);
+
+        // Assert
+        Assert.Equal(Failure<int>(exception), outcome);
+    }
 }

--- a/tests/BahmanM.Flow.Tests.Unit/ChainTests.cs
+++ b/tests/BahmanM.Flow.Tests.Unit/ChainTests.cs
@@ -74,4 +74,26 @@ public class ChainTests
         // Assert
         Assert.Equal(Success(20), outcome);
     }
+
+    [Fact]
+    public async Task AsyncChain_OnFailedFlow_DoesNotExecuteAndPropagatesFailure()
+    {
+        // Arrange
+        var exception = new Exception("Initial failure");
+        var initialFlow = Flow.Fail<int>(exception);
+        var chainExecuted = false;
+        var chainedFlow = initialFlow.Chain(async value =>
+        {
+            chainExecuted = true;
+            await Task.Delay(10);
+            return Flow.Succeed(value * 2);
+        });
+
+        // Act
+        var outcome = await FlowEngine.ExecuteAsync(chainedFlow);
+
+        // Assert
+        Assert.False(chainExecuted);
+        Assert.Equal(Failure<int>(exception), outcome);
+    }
 }

--- a/tests/BahmanM.Flow.Tests.Unit/ChainTests.cs
+++ b/tests/BahmanM.Flow.Tests.Unit/ChainTests.cs
@@ -41,4 +41,19 @@ public class ChainTests
         Assert.False(chainExecuted);
         Assert.Equal(Failure<int>(exception), outcome);
     }
+
+    [Fact]
+    public async Task WhenChainFunctionThrows_ReturnsFailure()
+    {
+        // Arrange
+        var exception = new InvalidOperationException("Chain function failed!");
+        var initialFlow = Flow.Succeed(10);
+        var chainedFlow = initialFlow.Chain<int, int>(value => throw exception);
+
+        // Act
+        var outcome = await FlowEngine.ExecuteAsync(chainedFlow);
+
+        // Assert
+        Assert.Equal(Failure<int>(exception), outcome);
+    }
 }


### PR DESCRIPTION
This PR implements the `Chain` operator as defined in issue #60. It includes both synchronous and asynchronous versions, along with comprehensive unit tests covering success, failure, and exception scenarios.