### PR TITLE
[#15] Implement DoOnFailure operator

### DIFF
--- a/src/BahmanM.Flow/FlowExtensions.cs
+++ b/src/BahmanM.Flow/FlowExtensions.cs
@@ -8,6 +8,12 @@ public static class FlowExtensions
     public static IFlow<T> DoOnSuccess<T>(this IFlow<T> flow, Func<T, Task> asyncAction) =>
         new AsyncDoOnSuccessNode<T>(flow, asyncAction);
 
+    public static IFlow<T> DoOnFailure<T>(this IFlow<T> flow, Action<Exception> action) =>
+        new DoOnFailureNode<T>(flow, action);
+
+    public static IFlow<T> DoOnFailure<T>(this IFlow<T> flow, Func<Exception, Task> asyncAction) =>
+        new AsyncDoOnFailureNode<T>(flow, asyncAction);
+
     public static IFlow<TOut> Select<TIn, TOut>(this IFlow<TIn> flow, Func<TIn, TOut> operation) =>
         new SelectNode<TIn, TOut>(flow, operation);
 

--- a/src/BahmanM.Flow/FlowTypes.cs
+++ b/src/BahmanM.Flow/FlowTypes.cs
@@ -60,6 +60,22 @@ internal sealed record AsyncDoOnSuccessNode<T>(IFlow<T> Upstream, Func<T, Task> 
 
 #endregion
 
+#region DoOnFailure Nodes
+
+internal sealed record DoOnFailureNode<T>(IFlow<T> Upstream, Action<Exception> Action) : IFlowNode<T>
+{
+    public Task<Outcome<T>> ExecuteWith(FlowEngine engine) => engine.Execute(this);
+    public IFlow<T> Apply(IBehaviourStrategy strategy) => strategy.ApplyTo<T>(this);
+}
+
+internal sealed record AsyncDoOnFailureNode<T>(IFlow<T> Upstream, Func<Exception, Task> AsyncAction) : IFlowNode<T>
+{
+    public Task<Outcome<T>> ExecuteWith(FlowEngine engine) => engine.Execute(this);
+    public IFlow<T> Apply(IBehaviourStrategy strategy) => strategy.ApplyTo<T>(this);
+}
+
+#endregion
+
 #region Select Nodes
 
 internal sealed record SelectNode<TIn, TOut>(IFlow<TIn> Upstream, Func<TIn, TOut> Operation) : IFlowNode<TOut>

--- a/src/BahmanM.Flow/IBehaviourStrategy.cs
+++ b/src/BahmanM.Flow/IBehaviourStrategy.cs
@@ -8,6 +8,8 @@ internal interface IBehaviourStrategy
     IFlow<T> ApplyTo<T>(AsyncCreateNode<T> node);
     IFlow<T> ApplyTo<T>(DoOnSuccessNode<T> node);
     IFlow<T> ApplyTo<T>(AsyncDoOnSuccessNode<T> node);
+    IFlow<T> ApplyTo<T>(DoOnFailureNode<T> node);
+    IFlow<T> ApplyTo<T>(AsyncDoOnFailureNode<T> node);
     IFlow<TOut> ApplyTo<TIn, TOut>(SelectNode<TIn, TOut> node);
     IFlow<TOut> ApplyTo<TIn, TOut>(AsyncSelectNode<TIn, TOut> node);
     IFlow<TOut> ApplyTo<TIn, TOut>(ChainNode<TIn, TOut> node);

--- a/src/BahmanM.Flow/TimeoutStrategy.cs
+++ b/src/BahmanM.Flow/TimeoutStrategy.cs
@@ -19,6 +19,8 @@ internal class TimeoutStrategy(TimeSpan duration) : IBehaviourStrategy
 
     public IFlow<T> ApplyTo<T>(DoOnSuccessNode<T> node) => node;
     public IFlow<T> ApplyTo<T>(AsyncDoOnSuccessNode<T> node) => node;
+    public IFlow<T> ApplyTo<T>(DoOnFailureNode<T> node) => node;
+    public IFlow<T> ApplyTo<T>(AsyncDoOnFailureNode<T> node) => node;
     public IFlow<TOut> ApplyTo<TIn, TOut>(SelectNode<TIn, TOut> node) => node;
     public IFlow<TOut> ApplyTo<TIn, TOut>(AsyncSelectNode<TIn, TOut> node) => node;
 

--- a/tests/BahmanM.Flow.Tests.Unit/DoOnFailureTests.cs
+++ b/tests/BahmanM.Flow.Tests.Unit/DoOnFailureTests.cs
@@ -1,0 +1,124 @@
+using static BahmanM.Flow.Outcome;
+
+namespace BahmanM.Flow.Tests.Unit;
+
+public class DoOnFailureTests
+{
+    // Zeno of Citium (c. 334 – c. 262 BC) was a Hellenistic philosopher
+    // from Citium, Cyprus. Zeno was the founder of the Stoic school of philosophy.
+    private static readonly Exception ZenosException = new InvalidOperationException("Zeno's Paradox");
+
+    [Fact]
+    public async Task WhenFlowFails_CallsActionAndReturnsOriginalFailure()
+    {
+        // Arrange
+        var actionCalled = false;
+        Exception? capturedException = null;
+        Action<Exception> onFailure = ex =>
+        {
+            actionCalled = true;
+            capturedException = ex;
+        };
+
+
+        var flow = Flow.Fail<string>(ZenosException).DoOnFailure(onFailure);
+
+        // Act
+        var outcome = await FlowEngine.ExecuteAsync(flow);
+
+        // Assert
+        Assert.True(actionCalled);
+        Assert.Same(ZenosException, capturedException);
+        Assert.Equal(Failure<string>(ZenosException), outcome);
+    }
+
+    [Fact]
+    public async Task WhenFlowSucceeds_DoesNotCallActionAndReturnsOriginalSuccess()
+    {
+        // Arrange
+        var actionCalled = false;
+        Action<Exception> onFailure = _ => actionCalled = true;
+        var flow = Flow.Succeed("Success").DoOnFailure(onFailure);
+
+        // Act
+        var outcome = await FlowEngine.ExecuteAsync(flow);
+
+        // Assert
+        Assert.False(actionCalled);
+        Assert.Equal(Success("Success"), outcome);
+    }
+
+    [Fact]
+    public async Task WhenActionThrows_ReturnsOriginalFailure()
+    {
+        // Arrange
+        var actionException = new InvalidOperationException("Action failed!");
+        Action<Exception> onFailure = _ => throw actionException;
+        var flow = Flow.Fail<string>(ZenosException).DoOnFailure(onFailure);
+
+        // Act
+        var outcome = await FlowEngine.ExecuteAsync(flow);
+
+        // Assert
+        Assert.Equal(Failure<string>(ZenosException), outcome);
+    }
+
+    [Fact]
+    public async Task WhenFlowFails_CallsAsyncActionAndReturnsOriginalFailure()
+    {
+        // Arrange
+        var actionCalled = false;
+        Exception? capturedException = null;
+        Func<Exception, Task> onFailure = async ex =>
+        {
+            await Task.Delay(1);
+            actionCalled = true;
+            capturedException = ex;
+        };
+
+        var flow = Flow.Fail<string>(ZenosException).DoOnFailure(onFailure);
+
+        // Act
+        var outcome = await FlowEngine.ExecuteAsync(flow);
+
+        // Assert
+        Assert.True(actionCalled);
+        Assert.Same(ZenosException, capturedException);
+        Assert.Equal(Failure<string>(ZenosException), outcome);
+    }
+
+    [Fact]
+    public async Task WhenFlowSucceeds_DoesNotCallAsyncActionAndReturnsOriginalSuccess()
+    {
+        // Arrange
+        var actionCalled = false;
+        Func<Exception, Task> onFailure = async _ =>
+        {
+            await Task.Delay(1);
+            actionCalled = true;
+        };
+        var flow = Flow.Succeed("Success").DoOnFailure(onFailure);
+
+        // Act
+        var outcome = await FlowEngine.ExecuteAsync(flow);
+
+        // Assert
+        Assert.False(actionCalled);
+        Assert.Equal(Success("Success"), outcome);
+    }
+
+    [Fact]
+    public async Task WhenAsyncActionThrows_ReturnsOriginalFailure()
+    {
+        // Arrange
+        var actionException = new InvalidOperationException("Action failed!");
+        Func<Exception, Task> onFailure = _ => throw actionException;
+        var flow = Flow.Fail<string>(ZenosException).DoOnFailure(onFailure);
+
+        // Act
+        var outcome = await FlowEngine.ExecuteAsync(flow);
+
+        // Assert
+        Assert.Equal(Failure<string>(ZenosException), outcome);
+    }
+}


### PR DESCRIPTION
This pull request introduces the `.DoOnFailure()` operator, the necessary counterpart to `.DoOnSuccess()`. It allows for side-effects to be performed on a failed flow without altering the outcome.

This is a fundamental operator for logging, monitoring, and is a prerequisite for implementing more complex behaviours like the Circuit Breaker described in the documentation.

- Implements both synchronous and asynchronous versions of the operator.
- Adds a comprehensive suite of unit tests to verify all behaviors.
- Updates the internal `IBehaviourStrategy` interface to be exhaustive over the new node types, ensuring compile-time safety for future behaviours.