### PR TITLE
[#71] Refactor API to use specific delegates (Part 1: DoOnSuccess)

### DIFF
--- a/src/BahmanM.Flow/CustomBehaviourStrategy.cs
+++ b/src/BahmanM.Flow/CustomBehaviourStrategy.cs
@@ -8,6 +8,11 @@ internal class CustomBehaviourStrategy(IBehaviour behaviour) : IBehaviourStrateg
     public IFlow<T> ApplyTo<T>(AsyncCreateNode<T> node) => behaviour.Apply(node);
     public IFlow<T> ApplyTo<T>(DoOnSuccessNode<T> node) => behaviour.Apply(node);
     public IFlow<T> ApplyTo<T>(AsyncDoOnSuccessNode<T> node) => behaviour.Apply(node);
+    public IFlow<T> ApplyTo<T>(CancellableAsyncDoOnSuccessNode<T> node)
+    {
+        throw new NotImplementedException();
+    }
+
     public IFlow<T> ApplyTo<T>(DoOnFailureNode<T> node) => behaviour.Apply(node);
     public IFlow<T> ApplyTo<T>(AsyncDoOnFailureNode<T> node) => behaviour.Apply(node);
     public IFlow<TOut> ApplyTo<TIn, TOut>(SelectNode<TIn, TOut> node) => behaviour.Apply(node);

--- a/src/BahmanM.Flow/FlowEngine.cs
+++ b/src/BahmanM.Flow/FlowEngine.cs
@@ -10,11 +10,29 @@ public class FlowEngine
         return node.ExecuteWith(new FlowEngine());
     }
 
+    public static Task<Outcome<T>> ExecuteAsync<T>(IFlow<T> flow, FlowExecutionOptions options)
+    {
+        var node = (IFlowNode<T>)flow;
+        return node.ExecuteWith(new FlowEngine(options));
+    }
+
     #endregion
 
     #region Constructors
 
-    private FlowEngine() { }
+    private readonly FlowExecutionOptions _options;
+
+    private CancellationToken CancellationToken => _options.CancellationToken;
+
+    private FlowEngine()
+    {
+        _options = new FlowExecutionOptions();
+    }
+
+    private FlowEngine(FlowExecutionOptions options)
+    {
+        _options = options;
+    }
 
     #endregion
 
@@ -80,9 +98,7 @@ public class FlowEngine
         {
             try
             {
-                // This needs the CancellationToken from the engine, which isn't available yet.
-                // This will be properly implemented when we tackle issue #68.
-                await node.AsyncAction(success.Value, CancellationToken.None);
+                await node.AsyncAction(success.Value, CancellationToken);
                 return upstreamOutcome;
             }
             catch (Exception ex)

--- a/src/BahmanM.Flow/FlowExtensions.cs
+++ b/src/BahmanM.Flow/FlowExtensions.cs
@@ -2,11 +2,14 @@ namespace BahmanM.Flow;
 
 public static class FlowExtensions
 {
-    public static IFlow<T> DoOnSuccess<T>(this IFlow<T> flow, Action<T> action) =>
+    public static IFlow<T> DoOnSuccess<T>(this IFlow<T> flow, Operations.DoOnSuccess.Sync<T> action) =>
         new DoOnSuccessNode<T>(flow, action);
 
-    public static IFlow<T> DoOnSuccess<T>(this IFlow<T> flow, Func<T, Task> asyncAction) =>
+    public static IFlow<T> DoOnSuccess<T>(this IFlow<T> flow, Operations.DoOnSuccess.Async<T> asyncAction) =>
         new AsyncDoOnSuccessNode<T>(flow, asyncAction);
+
+    public static IFlow<T> DoOnSuccess<T>(this IFlow<T> flow, Operations.DoOnSuccess.CancellableAsync<T> asyncAction) =>
+        new CancellableAsyncDoOnSuccessNode<T>(flow, asyncAction);
 
     public static IFlow<T> DoOnFailure<T>(this IFlow<T> flow, Action<Exception> action) =>
         new DoOnFailureNode<T>(flow, action);

--- a/src/BahmanM.Flow/FlowTypes.cs
+++ b/src/BahmanM.Flow/FlowTypes.cs
@@ -46,13 +46,21 @@ internal sealed record AsyncCreateNode<T>(Func<Task<T>> Operation) : IFlowNode<T
 
 #region DoOnSuccess Nodes
 
-internal sealed record DoOnSuccessNode<T>(IFlow<T> Upstream, Action<T> Action) : IFlowNode<T>
+internal sealed record DoOnSuccessNode<T>(IFlow<T> Upstream, Operations.DoOnSuccess.Sync<T> Action) : IFlowNode<T>
 {
     public Task<Outcome<T>> ExecuteWith(FlowEngine engine) => engine.Execute(this);
     public IFlow<T> Apply(IBehaviourStrategy strategy) => strategy.ApplyTo(this);
 }
 
-internal sealed record AsyncDoOnSuccessNode<T>(IFlow<T> Upstream, Func<T, Task> AsyncAction) : IFlowNode<T>
+internal sealed record AsyncDoOnSuccessNode<T>(IFlow<T> Upstream, Operations.DoOnSuccess.Async<T> AsyncAction) : IFlowNode<T>
+{
+    public Task<Outcome<T>> ExecuteWith(FlowEngine engine) => engine.Execute(this);
+    public IFlow<T> Apply(IBehaviourStrategy strategy) => strategy.ApplyTo(this);
+}
+
+internal sealed record CancellableAsyncDoOnSuccessNode<T>(
+    IFlow<T> Upstream,
+    Operations.DoOnSuccess.CancellableAsync<T> AsyncAction) : IFlowNode<T>
 {
     public Task<Outcome<T>> ExecuteWith(FlowEngine engine) => engine.Execute(this);
     public IFlow<T> Apply(IBehaviourStrategy strategy) => strategy.ApplyTo(this);

--- a/src/BahmanM.Flow/IBehaviourStrategy.cs
+++ b/src/BahmanM.Flow/IBehaviourStrategy.cs
@@ -8,6 +8,7 @@ internal interface IBehaviourStrategy
     IFlow<T> ApplyTo<T>(AsyncCreateNode<T> node);
     IFlow<T> ApplyTo<T>(DoOnSuccessNode<T> node);
     IFlow<T> ApplyTo<T>(AsyncDoOnSuccessNode<T> node);
+    IFlow<T> ApplyTo<T>(CancellableAsyncDoOnSuccessNode<T> node);
     IFlow<T> ApplyTo<T>(DoOnFailureNode<T> node);
     IFlow<T> ApplyTo<T>(AsyncDoOnFailureNode<T> node);
     IFlow<TOut> ApplyTo<TIn, TOut>(SelectNode<TIn, TOut> node);

--- a/src/BahmanM.Flow/Operations.cs
+++ b/src/BahmanM.Flow/Operations.cs
@@ -1,0 +1,50 @@
+namespace BahmanM.Flow;
+
+public static class Operations
+{
+    public static class Create
+    {
+        public delegate T Sync<out T>();
+        public delegate Task<T> Async<T>();
+        public delegate Task<T> CancellableAsync<T>(CancellationToken cancellationToken);
+    }
+
+    public static class Select
+    {
+        public delegate TOut Sync<in TIn, out TOut>(TIn input);
+        public delegate Task<TOut> Async<in TIn, TOut>(TIn input);
+        public delegate Task<TOut> CancellableAsync<in TIn, TOut>(TIn input, CancellationToken cancellationToken);
+    }
+
+    public static class Chain
+    {
+        public delegate IFlow<TOut> Sync<in TIn, TOut>(TIn input);
+        public delegate Task<IFlow<TOut>> Async<in TIn, TOut>(TIn input);
+        public delegate Task<IFlow<TOut>> CancellableAsync<in TIn, TOut>(TIn input, CancellationToken cancellationToken);
+    }
+
+    public static class DoOnSuccess
+    {
+        public delegate void Sync<in T>(T input);
+        public delegate Task Async<in T>(T input);
+        public delegate Task CancellableAsync<in T>(T input, CancellationToken cancellationToken);
+    }
+
+    public static class DoOnFailure
+    {
+        public delegate void Sync(Exception error);
+        public delegate Task Async(Exception error);
+        public delegate Task CancellableAsync(Exception error, CancellationToken cancellationToken);
+    }
+
+    public static class Recover
+    {
+        public delegate T Sync<out T>(Exception error);
+        public delegate Task<T> Async<T>(Exception error);
+        public delegate Task<T> CancellableAsync<T>(Exception error, CancellationToken cancellationToken);
+        
+        public delegate IFlow<T> SyncWithFlow<T>(Exception error);
+        public delegate Task<IFlow<T>> AsyncWithFlow<T>(Exception error);
+        public delegate Task<IFlow<T>> CancellableAsyncWithFlow<T>(Exception error, CancellationToken cancellationToken);
+    }
+}

--- a/src/BahmanM.Flow/RetryStrategy.cs
+++ b/src/BahmanM.Flow/RetryStrategy.cs
@@ -25,6 +25,10 @@ internal class RetryStrategy : IBehaviourStrategy
     public IFlow<T> ApplyTo<T>(DoOnSuccessNode<T> node) => node;
 
     public IFlow<T> ApplyTo<T>(AsyncDoOnSuccessNode<T> node) => node;
+    public IFlow<T> ApplyTo<T>(CancellableAsyncDoOnSuccessNode<T> node)
+    {
+        throw new NotImplementedException();
+    }
 
     public IFlow<T> ApplyTo<T>(DoOnFailureNode<T> node) => node;
 

--- a/src/BahmanM.Flow/TimeoutStrategy.cs
+++ b/src/BahmanM.Flow/TimeoutStrategy.cs
@@ -23,6 +23,11 @@ internal class TimeoutStrategy(TimeSpan duration) : IBehaviourStrategy
     public IFlow<T> ApplyTo<T>(AsyncDoOnSuccessNode<T> node) =>
         node with { Upstream = ((IFlowNode<T>)node.Upstream).Apply(this) };
 
+    public IFlow<T> ApplyTo<T>(CancellableAsyncDoOnSuccessNode<T> node)
+    {
+        throw new NotImplementedException();
+    }
+
     public IFlow<T> ApplyTo<T>(DoOnFailureNode<T> node) =>
         node with { Upstream = ((IFlowNode<T>)node.Upstream).Apply(this) };
 

--- a/tests/BahmanM.Flow.Tests.Unit/DoOnSuccessTests.cs
+++ b/tests/BahmanM.Flow.Tests.Unit/DoOnSuccessTests.cs
@@ -10,7 +10,7 @@ public class DoOnSuccessTests
         // Arrange
         var successValue = 123;
         var actionCalled = false;
-        Action<int> onSuccess = val =>
+        Operations.DoOnSuccess.Sync<int> onSuccess = val =>
         {
             Assert.Equal(successValue, val);
             actionCalled = true;
@@ -32,7 +32,7 @@ public class DoOnSuccessTests
         // Arrange
         var exception = new InvalidOperationException("Test Failure");
         var actionCalled = false;
-        Action<int> onSuccess = _ => actionCalled = true;
+        Operations.DoOnSuccess.Sync<int> onSuccess = _ => actionCalled = true;
 
         var flow = Flow.Fail<int>(exception).DoOnSuccess(onSuccess);
 
@@ -50,7 +50,7 @@ public class DoOnSuccessTests
         // Arrange
         var successValue = 123;
         var exception = new InvalidOperationException("Action failed!");
-        Action<int> onSuccess = _ => throw exception;
+        Operations.DoOnSuccess.Sync<int> onSuccess = _ => throw exception;
 
         var flow = Flow.Succeed(successValue).DoOnSuccess(onSuccess);
 
@@ -67,7 +67,7 @@ public class DoOnSuccessTests
         // Arrange
         var successValue = 123;
         var actionCalled = false;
-        Func<int, Task> onSuccess = async val =>
+        Operations.DoOnSuccess.Async<int> onSuccess = async val =>
         {
             Assert.Equal(successValue, val);
             await Task.Delay(10);
@@ -90,7 +90,7 @@ public class DoOnSuccessTests
         // Arrange
         var exception = new InvalidOperationException("Test Failure");
         var actionCalled = false;
-        Func<int, Task> onSuccess = async _ =>
+        Operations.DoOnSuccess.Async<int> onSuccess = async _ =>
         {
             await Task.Delay(10);
             actionCalled = true;
@@ -112,7 +112,7 @@ public class DoOnSuccessTests
         // Arrange
         var successValue = 123;
         var exception = new InvalidOperationException("Action failed!");
-        Func<int, Task> onSuccess = _ => throw exception;
+        Operations.DoOnSuccess.Async<int> onSuccess = _ => throw exception;
 
         var flow = Flow.Succeed(successValue).DoOnSuccess(onSuccess);
 


### PR DESCRIPTION
This PR begins the work for issue #71 by refactoring the  operator and the .

Key changes:
- Introduces  to define a clear vocabulary for flow delegates.
- Refactors  to use these new, specific delegates, including adding a  overload.
- Refactors the  to hold a  object, making it more extensible for future options (like cancellation and diagnostics).

This is the first step in a larger refactoring to improve API clarity.