### PR TITLE
[#75] Relocate primitive AST nodes

### DIFF
--- a/src/BahmanM.Flow/Ast/Primitive/Fail.cs
+++ b/src/BahmanM.Flow/Ast/Primitive/Fail.cs
@@ -1,4 +1,4 @@
-namespace BahmanM.Flow.Ast.Pure;
+namespace BahmanM.Flow.Ast.Primitive;
 
 internal sealed record Fail<T>(Exception Exception) : INode<T>
 {

--- a/src/BahmanM.Flow/Ast/Primitive/Succeed.cs
+++ b/src/BahmanM.Flow/Ast/Primitive/Succeed.cs
@@ -1,4 +1,4 @@
-namespace BahmanM.Flow.Ast.Pure;
+namespace BahmanM.Flow.Ast.Primitive;
 
 internal sealed record Succeed<T>(T Value) : INode<T>
 {

--- a/src/BahmanM.Flow/CustomBehaviourStrategy.cs
+++ b/src/BahmanM.Flow/CustomBehaviourStrategy.cs
@@ -1,9 +1,11 @@
+using BahmanM.Flow.Ast.Primitive;
+
 namespace BahmanM.Flow;
 
 internal class CustomBehaviourStrategy(IBehaviour behaviour) : IBehaviourStrategy
 {
-    public IFlow<T> ApplyTo<T>(Ast.Pure.Succeed<T> node) => behaviour.Apply(node);
-    public IFlow<T> ApplyTo<T>(Ast.Pure.Fail<T> node) => behaviour.Apply(node);
+    public IFlow<T> ApplyTo<T>(Succeed<T> node) => behaviour.Apply(node);
+    public IFlow<T> ApplyTo<T>(Fail<T> node) => behaviour.Apply(node);
     public IFlow<T> ApplyTo<T>(Ast.Create.Sync<T> node) => behaviour.Apply(node);
     public IFlow<T> ApplyTo<T>(Ast.Create.Async<T> node) => behaviour.Apply(node);
     public IFlow<T> ApplyTo<T>(Ast.Create.CancellableAsync<T> node) => behaviour.Apply(node);

--- a/src/BahmanM.Flow/Flow.cs
+++ b/src/BahmanM.Flow/Flow.cs
@@ -4,9 +4,9 @@ namespace BahmanM.Flow;
 
 public static class Flow
 {
-    public static IFlow<T> Succeed<T>(T value) => new Ast.Pure.Succeed<T>(value);
+    public static IFlow<T> Succeed<T>(T value) => new Succeed<T>(value);
 
-    public static IFlow<T> Fail<T>(Exception exception) => new Ast.Pure.Fail<T>(exception);
+    public static IFlow<T> Fail<T>(Exception exception) => new Fail<T>(exception);
 
     public static IFlow<T> Create<T>(Func<T> operation) => new Ast.Create.Sync<T>(() => operation());
 

--- a/src/BahmanM.Flow/FlowEngine.cs
+++ b/src/BahmanM.Flow/FlowEngine.cs
@@ -1,3 +1,5 @@
+using BahmanM.Flow.Ast.Primitive;
+
 namespace BahmanM.Flow;
 
 public class FlowEngine
@@ -38,10 +40,10 @@ public class FlowEngine
 
     #region Visitor Methods
 
-    internal Task<Outcome<T>> Execute<T>(Ast.Pure.Succeed<T> node) =>
+    internal Task<Outcome<T>> Execute<T>(Succeed<T> node) =>
         Task.FromResult(Outcome.Success(node.Value));
 
-    internal Task<Outcome<T>> Execute<T>(Ast.Pure.Fail<T> node) =>
+    internal Task<Outcome<T>> Execute<T>(Fail<T> node) =>
         Task.FromResult(Outcome.Failure<T>(node.Exception));
 
     internal Task<Outcome<T>> Execute<T>(Ast.Create.Sync<T> node) =>

--- a/src/BahmanM.Flow/IBehaviourStrategy.cs
+++ b/src/BahmanM.Flow/IBehaviourStrategy.cs
@@ -1,9 +1,11 @@
+using BahmanM.Flow.Ast.Primitive;
+
 namespace BahmanM.Flow;
 
 internal interface IBehaviourStrategy
 {
-    IFlow<T> ApplyTo<T>(Ast.Pure.Succeed<T> node);
-    IFlow<T> ApplyTo<T>(Ast.Pure.Fail<T> node);
+    IFlow<T> ApplyTo<T>(Succeed<T> node);
+    IFlow<T> ApplyTo<T>(Fail<T> node);
     IFlow<T> ApplyTo<T>(Ast.Create.Sync<T> node);
     IFlow<T> ApplyTo<T>(Ast.Create.Async<T> node);
     IFlow<T> ApplyTo<T>(Ast.Create.CancellableAsync<T> node);

--- a/src/BahmanM.Flow/RetryStrategy.cs
+++ b/src/BahmanM.Flow/RetryStrategy.cs
@@ -1,3 +1,5 @@
+using BahmanM.Flow.Ast.Primitive;
+
 namespace BahmanM.Flow;
 
 internal class RetryStrategy : IBehaviourStrategy
@@ -19,8 +21,8 @@ internal class RetryStrategy : IBehaviourStrategy
 
     #region Pass-through Implementations
 
-    public IFlow<T> ApplyTo<T>(Ast.Pure.Succeed<T> node) => node;
-    public IFlow<T> ApplyTo<T>(Ast.Pure.Fail<T> node) => node;
+    public IFlow<T> ApplyTo<T>(Succeed<T> node) => node;
+    public IFlow<T> ApplyTo<T>(Fail<T> node) => node;
     public IFlow<T> ApplyTo<T>(Ast.Create.CancellableAsync<T> node)
     {
         throw new NotImplementedException();

--- a/src/BahmanM.Flow/TimeoutStrategy.cs
+++ b/src/BahmanM.Flow/TimeoutStrategy.cs
@@ -1,9 +1,11 @@
+using BahmanM.Flow.Ast.Primitive;
+
 namespace BahmanM.Flow;
 
 internal class TimeoutStrategy(TimeSpan duration) : IBehaviourStrategy
 {
-    public IFlow<T> ApplyTo<T>(Ast.Pure.Succeed<T> node) => node;
-    public IFlow<T> ApplyTo<T>(Ast.Pure.Fail<T> node) => node;
+    public IFlow<T> ApplyTo<T>(Succeed<T> node) => node;
+    public IFlow<T> ApplyTo<T>(Fail<T> node) => node;
 
     public IFlow<T> ApplyTo<T>(Ast.Create.Sync<T> node)
     {


### PR DESCRIPTION
- Moved `Succeed<T>` and `Fail<T>` from `BahmanM.Flow.Ast.Pure` to `BahmanM.Flow.Ast.Primitive` namespace.
- Updated all references to these types across the codebase to reflect the new namespace.
- This change clarifies the nature of these nodes as fundamental building blocks of the flow AST.